### PR TITLE
Add .ssl syntax highlighting via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,5 @@ data/text/spanish/**    working-tree-encoding=cp1252
 data/text/schinese/**   working-tree-encoding=cp936
 data/text/tchinese/**   working-tree-encoding=cp950
 data/text/ukrainian/**  working-tree-encoding=cp1251
+
+*.ssl linguist-language=Pascal


### PR DESCRIPTION
Hey there, love FO2Tweaks. But the .ssl is challenging to read on GitHub without syntax highlighting.

This registers .ssl as Pascal for highlighting, which works very well. ([As seen in the ettu repo here](https://github.com/rotators/Fo1in2/blob/dd2bc20a895d216770583f87f11a872475e18ca6/.gitattributes#L6))